### PR TITLE
Extend node engine range, update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,43 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/ms-rest-azure-env": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-1.1.2.tgz",
+      "integrity": "sha512-l7z0DPCi2Hp88w12JhDTtx5d0Y3+vhfE7JKJb9O7sEz71Cwp053N8piTtTnnk/tUor9oZHgEKi/p3tQQmLPjvA==",
+      "dev": true
+    },
+    "@azure/ms-rest-js": {
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.13.tgz",
+      "integrity": "sha512-jAa6Y2XrvwbEqkaEXDHK+ReNo0WnCPS+LgQ1dRAJUUNxK4CghF5u+SXsVtPENritilVE7FVteqsLOtlhTk+haA==",
+      "dev": true,
+      "requires": {
+        "@types/tunnel": "0.0.0",
+        "axios": "^0.19.0",
+        "form-data": "^2.3.2",
+        "tough-cookie": "^2.4.3",
+        "tslib": "^1.9.2",
+        "tunnel": "0.0.6",
+        "uuid": "^3.2.1",
+        "xml2js": "^0.4.19"
+      }
+    },
+    "@azure/ms-rest-nodeauth": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-2.0.2.tgz",
+      "integrity": "sha512-KmNNICOxt3EwViAJI3iu2VH8t8BQg5J2rSAyO4IUYLF9ZwlyYsP419pdvl4NBUhluAP2cgN7dfD2V6E6NOMZlQ==",
+      "dev": true,
+      "requires": {
+        "@azure/ms-rest-azure-env": "^1.1.2",
+        "@azure/ms-rest-js": "^1.8.7",
+        "adal-node": "^0.1.28"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
@@ -15,8 +48,8 @@
     },
     "@babel/highlight": {
       "version": "7.5.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -25,26 +58,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.5.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@babel/runtime/-/runtime-7.5.5.tgz",
-      "integrity": "sha1-dPulbTXvvspEQJHHhQzNSU/S8TI=",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U=",
-          "dev": true
-        }
       }
     },
     "@newrelic/koa": {
       "version": "1.0.8",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@newrelic/koa/-/koa-1.0.8.tgz",
-      "integrity": "sha1-Wb9U6GzvcAQn4y29x8kxohMUasE=",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
+      "integrity": "sha512-kY//FlLQkGdUIKEeGJlyY3dJRU63EG77YIa48ACMGZxQbWRd3WZMikyft33f8XScTq6WpCDo9xa0viNo8zeYkg==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2"
@@ -52,8 +77,8 @@
     },
     "@newrelic/native-metrics": {
       "version": "4.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@newrelic/native-metrics/-/native-metrics-4.1.0.tgz",
-      "integrity": "sha1-yxZB5VF5zW7AWEQa4LDu36Nu4Os=",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-4.1.0.tgz",
+      "integrity": "sha512-7CZlKMLuaYQW7mV9qVyo9b9HVe2xBnyn+kkETRJoZGs5P7gdfv9AAE3RPhtOBUopTfbmc8ju7njYadjui9J1XA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -63,40 +88,49 @@
     },
     "@newrelic/superagent": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@newrelic/superagent/-/superagent-1.0.3.tgz",
-      "integrity": "sha1-jG6oT4tGMnXFjnQCBL8pOcLipkk=",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-1.0.3.tgz",
+      "integrity": "sha512-lJbsqKa79qPLbHZsbiRaXl1jfzaXAN7zqqnLRqBY+zI/O5zcfyNngTmdi+9y+qIUq7xHYNaLsAxCXerrsoINKg==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2"
       }
     },
     "@types/node": {
-      "version": "8.10.51",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@types/node/-/node-8.10.51.tgz",
-      "integrity": "sha1-gGAIV8Ckeo6Lr8La5trtbbWONic=",
+      "version": "12.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz",
+      "integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==",
       "dev": true
+    },
+    "@types/tunnel": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
+      "integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@tyriar/fibonacci-heap": {
       "version": "2.0.9",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
-      "integrity": "sha1-3z3L2xuRghaGAfYxg2YVfuFmZuk=",
+      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
+      "integrity": "sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA==",
       "dev": true
     },
     "acorn": {
-      "version": "6.2.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/acorn/-/acorn-6.2.1.tgz",
-      "integrity": "sha1-PthCLW3sCeYSHMeoQ8qGozCoa1E=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "adal-node": {
       "version": "0.1.28",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/adal-node/-/adal-node-0.1.28.tgz",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
       "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
       "dev": true,
       "requires": {
@@ -109,12 +143,20 @@
         "uuid": "^3.1.0",
         "xmldom": ">= 0.1.x",
         "xpath.js": "~1.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.58",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.58.tgz",
+          "integrity": "sha512-NNcUk/rAdR7Pie7WiA5NHp345dTkD62qaxqscQXVIjCjog/ZXsrG8Wo7dZMZAzE7PSpA+qR2S3TYTeFCKuBFxQ==",
+          "dev": true
+        }
       }
     },
     "agent-base": {
       "version": "4.3.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -122,8 +164,8 @@
     },
     "ajv": {
       "version": "6.10.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -134,20 +176,20 @@
     },
     "ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
@@ -155,8 +197,8 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -164,7 +206,7 @@
     },
     "aria-query": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/aria-query/-/aria-query-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "dev": true,
       "requires": {
@@ -174,7 +216,7 @@
     },
     "array-includes": {
       "version": "3.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
@@ -184,8 +226,8 @@
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -193,26 +235,26 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/async/-/async-2.6.3.tgz",
-      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -220,26 +262,36 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
     },
     "axobject-query": {
       "version": "2.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/axobject-query/-/axobject-query-2.0.2.tgz",
-      "integrity": "sha1-6hh6vluQArN3+SXYv30cVhrfOPk=",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7"
@@ -247,65 +299,32 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
-    "big-number": {
-      "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/big-number/-/big-number-1.0.0.tgz",
-      "integrity": "sha1-oCd2B6CtsGSS0wmVRu8NVHeF3xg=",
-      "dev": true
-    },
     "bl": {
-      "version": "2.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/bl/-/bl-2.2.0.tgz",
-      "integrity": "sha1-4aV0zfUo5AUwGbuACwQcCsiNpJM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
+        "readable-stream": "^3.0.1"
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -314,32 +333,32 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -349,13 +368,13 @@
     },
     "chardet": {
       "version": "0.7.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
@@ -364,14 +383,14 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -379,35 +398,35 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha1-QUz1r3kKSMYKub5FJ9VtXkETPLE=",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -417,27 +436,27 @@
       }
     },
     "confusing-browser-globals": {
-      "version": "1.0.7",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
-      "integrity": "sha1-WuhSvVQakQ5/+y27hkotIaNq0ps=",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
+      "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
       "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
@@ -449,13 +468,13 @@
     },
     "damerau-levenshtein": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
-      "integrity": "sha1-eAz3FE6y6NvRw7uDrjEQDMwxpBQ=",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -464,14 +483,14 @@
     },
     "date-utils": {
       "version": "1.2.21",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/date-utils/-/date-utils-1.2.21.tgz",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
       "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
       "dev": true
     },
     "debug": {
       "version": "4.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
@@ -479,14 +498,14 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
@@ -494,29 +513,28 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
     },
     "doctrine": {
-      "version": "1.5.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/doctrine/-/doctrine-1.5.0.tgz",
-      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "^2.0.2"
       }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -526,8 +544,8 @@
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -535,37 +553,41 @@
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -575,13 +597,13 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -590,14 +612,35 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        }
+      }
+    },
     "eslint": {
       "version": "5.16.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint/-/eslint-5.16.0.tgz",
-      "integrity": "sha1-oeOsGq5KP72Clvz496tzFMu2q+o=",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -636,23 +679,12 @@
         "strip-json-comments": "^2.0.1",
         "table": "^5.2.3",
         "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "3.0.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/doctrine/-/doctrine-3.0.0.tgz",
-          "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
       }
     },
     "eslint-config-airbnb": {
       "version": "17.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
-      "integrity": "sha1-InLguGux4rE4zfiNB6O29M2j1iY=",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
+      "integrity": "sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^13.2.0",
@@ -662,8 +694,8 @@
     },
     "eslint-config-airbnb-base": {
       "version": "13.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-      "integrity": "sha1-9uqBRZ/03sLdogDDXx2PdBnVeUM=",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
       "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.5",
@@ -672,9 +704,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
-      "integrity": "sha1-9CmlO96fx2YOY1ORD9mW1ihNPCU=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.5.0.tgz",
+      "integrity": "sha512-cjXp8SbO9VFGW/Z7mbTydqS9to8Z58E5aYhj3e1+Hx7lS9s6gL5ILKNpCqZAFOVYRcSkWPFYljHrEh8QFEK5EQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -682,8 +714,8 @@
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
@@ -692,8 +724,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -701,7 +733,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -709,8 +741,8 @@
     },
     "eslint-module-utils": {
       "version": "2.4.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
-      "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -719,8 +751,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -728,7 +760,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -736,8 +768,8 @@
     },
     "eslint-plugin-import": {
       "version": "2.18.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-      "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -755,16 +787,26 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -772,8 +814,8 @@
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.2.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
-      "integrity": "sha1-uHKgnV3lGvcKl9se6n3JMwQ3CKo=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.5",
@@ -788,26 +830,26 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.14.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
-      "integrity": "sha1-kRAw3X6YuknhsiCFmVcYRqZr3xM=",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
+      "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.1.0",
+        "jsx-ast-utils": "^2.2.1",
         "object.entries": "^1.1.0",
         "object.fromentries": "^2.0.0",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
-        "resolve": "^1.10.1"
+        "resolve": "^1.12.0"
       },
       "dependencies": {
         "doctrine": {
           "version": "2.1.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
@@ -817,8 +859,8 @@
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -826,24 +868,24 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha1-4sPI26doQl+JfPD55R/i4kFIXUw=",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
       "version": "5.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/espree/-/espree-5.0.1.tgz",
-      "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.7",
@@ -853,14 +895,14 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -868,35 +910,35 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "external-editor": {
       "version": "3.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
         "chardet": "^0.7.0",
@@ -906,31 +948,31 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/figures/-/figures-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
@@ -939,8 +981,8 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
@@ -948,7 +990,7 @@
     },
     "find-up": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/find-up/-/find-up-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
@@ -957,8 +999,8 @@
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
         "flatted": "^2.0.0",
@@ -968,20 +1010,46 @@
     },
     "flatted": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -991,31 +1059,31 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-stdin": {
       "version": "6.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha1-ngm/cSs2CrkiXoEgSPcf3pyJZXs=",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -1023,9 +1091,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1038,26 +1106,26 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha1-jY/cc5d8sEEEchy1NmbBymTNMos=",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",
@@ -1066,8 +1134,8 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
@@ -1075,25 +1143,25 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -1103,9 +1171,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha1-Jx6o6Q+DasnxGdrM05wZ/337B5M=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
@@ -1114,8 +1182,8 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -1125,8 +1193,8 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -1134,14 +1202,14 @@
     },
     "ignore": {
       "version": "4.0.6",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "import-fresh": {
       "version": "3.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/import-fresh/-/import-fresh-3.1.0.tgz",
-      "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -1150,13 +1218,13 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -1166,14 +1234,14 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "inquirer": {
-      "version": "6.5.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/inquirer/-/inquirer-6.5.0.tgz",
-      "integrity": "sha1-IwMxfvyaTqfsLi32+GVptzSsz0I=",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -1193,14 +1261,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -1210,37 +1278,43 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -1249,8 +1323,8 @@
     },
     "is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
@@ -1258,77 +1332,83 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
+    "jsbi": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.1.1.tgz",
+      "integrity": "sha512-+HQESPaV0mRiH614z4JPVPAftcRC2p53x92lySPzUzFwJbJTMpzHz8OYUkcXPN3fOcHUe0NdVcHnCtX/1+eCrA==",
+      "dev": true
+    },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -1339,9 +1419,9 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.2.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-      "integrity": "sha1-TUlz6/i50oN+6RqCCMxm86J3bPs=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+      "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -1350,8 +1430,8 @@
     },
     "jwa": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "dev": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
@@ -1361,8 +1441,8 @@
     },
     "jws": {
       "version": "3.2.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "dev": true,
       "requires": {
         "jwa": "^1.4.1",
@@ -1371,7 +1451,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -1381,7 +1461,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -1393,7 +1473,7 @@
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/locate-path/-/locate-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
@@ -1403,14 +1483,14 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -1418,20 +1498,20 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
         "mime-db": "1.40.0"
@@ -1439,14 +1519,14 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -1454,13 +1534,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1469,39 +1549,39 @@
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "nan": {
       "version": "2.14.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
     "native-duplexpair": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
       "integrity": "sha1-eJkHjmS/PIo9cyYBs9QP8F21j6A=",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "newrelic": {
-      "version": "5.10.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/newrelic/-/newrelic-5.10.0.tgz",
-      "integrity": "sha1-/wnHBqNFFMadxYrE5SRD6o3j7cg=",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-5.13.1.tgz",
+      "integrity": "sha512-FRChTKLh29benj2r//8/q+nLX3oHYlaOkOAjCVkilbTpp8OwR84FFDZNWRVuocxWP+yPR6ayfPaNc0ueLp9R7g==",
       "dev": true,
       "requires": {
         "@newrelic/koa": "^1.0.8",
@@ -1510,7 +1590,9 @@
         "@tyriar/fibonacci-heap": "^2.0.7",
         "async": "^2.1.4",
         "concat-stream": "^2.0.0",
-        "https-proxy-agent": "^2.2.1",
+        "escodegen": "^1.11.1",
+        "esprima": "^4.0.1",
+        "https-proxy-agent": "^3.0.0",
         "json-stringify-safe": "^5.0.0",
         "readable-stream": "^3.1.1",
         "semver": "^5.3.0"
@@ -1518,14 +1600,14 @@
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -1536,26 +1618,32 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -1566,8 +1654,8 @@
     },
     "object.entries": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -1577,21 +1665,31 @@
       }
     },
     "object.fromentries": {
-      "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
+      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1"
+        "es-abstract": "^1.5.1"
       }
     },
     "object.values": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -1602,7 +1700,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -1611,7 +1709,7 @@
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/onetime/-/onetime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
@@ -1620,7 +1718,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -1634,14 +1732,14 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
         "p-try": "^1.0.0"
@@ -1649,7 +1747,7 @@
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/p-locate/-/p-locate-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
@@ -1658,14 +1756,14 @@
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
@@ -1673,7 +1771,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -1682,37 +1780,37 @@
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/path-type/-/path-type-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
@@ -1721,19 +1819,19 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
@@ -1742,32 +1840,26 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prettier": {
       "version": "1.18.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "prop-types": {
       "version": "15.7.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
@@ -1776,32 +1868,32 @@
       }
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha1-3xK1sbOjD1HDKerL3vmPOm4TbcY=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
       "dev": true
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha1-W7weLSkUHJ+9/tRWND/ivEMKahY=",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==",
       "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/read-pkg/-/read-pkg-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
@@ -1812,7 +1904,7 @@
     },
     "read-pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
@@ -1822,8 +1914,8 @@
     },
     "readable-stream": {
       "version": "3.4.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/readable-stream/-/readable-stream-3.4.0.tgz",
-      "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -1831,16 +1923,22 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
+    },
     "regexpp": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/request/-/request-2.88.0.tgz",
-      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -1863,12 +1961,41 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha1-6hDYEQN2mC/vV434/DC5rDCgej4=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -1876,13 +2003,13 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
@@ -1892,8 +2019,8 @@
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -1901,7 +2028,7 @@
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
@@ -1909,35 +2036,41 @@
       }
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -1946,20 +2079,20 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -1967,10 +2100,17 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true
+    },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -1979,14 +2119,14 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -1995,20 +2135,20 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -2024,26 +2164,46 @@
     },
     "string-width": {
       "version": "2.1.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
       }
     },
-    "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha1-/obnOLGVRK/nBGkkOyoe6SQOro0=",
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
@@ -2052,29 +2212,29 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
     },
     "table": {
-      "version": "5.4.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/table/-/table-5.4.4.tgz",
-      "integrity": "sha1-bg+I/a42knk9EHf9FypGZ6/phqY=",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
@@ -2085,14 +2245,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -2102,8 +2262,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -2112,78 +2272,86 @@
       }
     },
     "tedious": {
-      "version": "6.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/tedious/-/tedious-6.2.0.tgz",
-      "integrity": "sha1-EYFbRYUZZ/TUGi5GaLvQtO8AzYE=",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-6.6.0.tgz",
+      "integrity": "sha512-XBuo2iQxYD2dRKVXO7Z4BwopzwTtza3bnsMNWHxmFzr0Z8KemjXEAzUOXu4W2Nyn4lETh/Sw09d9bpNtDzfNoA==",
       "dev": true,
       "requires": {
-        "adal-node": "^0.1.22",
-        "big-number": "1.0.0",
-        "bl": "^2.2.0",
-        "depd": "^1.1.2",
-        "iconv-lite": "^0.4.23",
+        "@azure/ms-rest-nodeauth": "2.0.2",
+        "@types/node": "^12.7.11",
+        "bl": "^3.0.0",
+        "depd": "^2.0.0",
+        "iconv-lite": "^0.5.0",
+        "jsbi": "^3.1.1",
         "native-duplexpair": "^1.0.0",
         "punycode": "^2.1.0",
-        "readable-stream": "^3.1.1",
+        "readable-stream": "^3.4.0",
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {
+        "iconv-lite": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
         "sprintf-js": {
           "version": "1.1.2",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha1-2hdlJiv4wPVxdJ8q1sJjACB65nM=",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
           "dev": true
         }
       }
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tslib": {
       "version": "1.10.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -2192,13 +2360,13 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -2207,20 +2375,20 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "underscore": {
       "version": "1.9.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE=",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
       "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -2228,20 +2396,30 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -2250,7 +2428,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -2261,8 +2439,8 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -2270,35 +2448,52 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/write/-/write-1.0.3.tgz",
-      "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }
     },
+    "xml2js": {
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+      "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "util.promisify": "~1.0.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true
+    },
     "xmldom": {
       "version": "0.1.27",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/xmldom/-/xmldom-0.1.27.tgz",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
     },
     "xpath.js": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.ua-ecm.com:443/artifactory/api/npm/ua-npm-master/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E=",
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,26 +1,27 @@
 {
   "name": "tedious-newrelic",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Instrumentation for tedious node lib",
   "main": "index.js",
   "engines": {
-    "node": ">=6.0.0 <=12.0.0",
+    "node": ">=6.0.0 <13.0.0",
     "npm": ">=2.0.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.1",
-    "eslint-config-prettier": "^6.0.0",
+    "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.14.3",
-    "newrelic": "^5.8.0",
+    "eslint-plugin-react": "^7.16.0",
+    "eslint-utils": "^1.4.3",
+    "newrelic": "^5.13.1",
     "prettier": "^1.18.2",
-    "tedious": "^6.1.1"
+    "tedious": "^6.6.0"
   },
   "peerDependencies": {
-    "newrelic": "^4.8.1 || ^5.8.0",
-    "tedious": "^2.7.1 || ^3 || ^4 || ^5 || ^6.1.1"
+    "newrelic": "^4.8.1 || ^5.13.1",
+    "tedious": "^2.7.1 || ^3 || ^4 || ^5 || ^6.6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Allow node 12 engine versions
* Require `eslint-utils ^1.4.3` for security patch (result of npm audit)
* Upgrade peer deps newrelic & tedious
* Other package updates
* Rewrite `package-lock.json` using `registry.npmjs.org` instead of private enterprise registry